### PR TITLE
Adding an optional TimeSpan constructor parameter 

### DIFF
--- a/CloudConvert.API/CloudConvertAPI.cs
+++ b/CloudConvert.API/CloudConvertAPI.cs
@@ -49,14 +49,13 @@ namespace CloudConvert.API
     const string sandboxUrlSyncApi = "https://sync.api.sandbox.cloudconvert.com/v2";
     const string publicUrlSyncApi = "https://sync.api.cloudconvert.com/v2";
     static readonly char[] base64Padding = { '=' };
-
-
-    public CloudConvertAPI(string api_key, bool isSandbox = false)
+    
+    public CloudConvertAPI(string api_key, bool isSandbox = false, TimeSpan? httpClientTimeout = null)
     {
       _apiUrl = isSandbox ? sandboxUrlApi : publicUrlApi;
       _apiSyncUrl = isSandbox ? sandboxUrlSyncApi : publicUrlSyncApi;
       _api_key += api_key;
-      _restHelper = new RestHelper();
+      _restHelper = new RestHelper(httpClientTimeout);
     }
 
     public CloudConvertAPI(string url, string api_key)

--- a/CloudConvert.API/RestHelper.cs
+++ b/CloudConvert.API/RestHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using Newtonsoft.Json;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -8,9 +9,14 @@ namespace CloudConvert.API
   {
     private readonly HttpClient _httpClient;
 
-    internal RestHelper()
+    internal RestHelper(TimeSpan? httpClientTimeout = null)
     {
       _httpClient = new HttpClient(new WebApiHandler(true));
+      
+      if (httpClientTimeout != null)
+      {
+        _httpClient.Timeout = httpClientTimeout.Value;
+      }
     }
 
     public async Task<T> RequestAsync<T>(HttpRequestMessage request)


### PR DESCRIPTION
This PR is a non-breaking change that enables setting the `HttpClient.Timeout` property inside `RestHelper.cs`.

Without this change, we are stuck with HttpClient's default of 100 seconds, which is not enough time for large file conversions.