### PR TITLE
Fix UTF8 filenames

### DIFF
--- a/CloudConvert.API/CloudConvertAPI.cs
+++ b/CloudConvert.API/CloudConvertAPI.cs
@@ -95,7 +95,9 @@ namespace CloudConvert.API
         }
       }
 
-      content.Add(new ByteArrayContent(file), "file", fileName);
+      var fileContent = new ByteArrayContent(file);
+      fileContent.Headers.Add("Content-Disposition", $"form-data; name=\"file\"; filename=\"{ new string(Encoding.UTF8.GetBytes(fileName).Select(b => (char)b).ToArray())}\"");
+      content.Add(fileContent);
 
       request.Content = content;
 


### PR DESCRIPTION
`MultipartFormDataContent` for some reason creates invalid `filename` values which results in filenames like `=?utf-8?...`.

This PR tries to fix this by manually encoding the filenames.