### PR TITLE
Added Stream to UploadAsync

### DIFF
--- a/CloudConvert.API/CloudConvert.API.csproj
+++ b/CloudConvert.API/CloudConvert.API.csproj
@@ -11,7 +11,11 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
-    
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="CloudConvert.Test" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2021.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/CloudConvert.API/CloudConvertAPI.cs
+++ b/CloudConvert.API/CloudConvertAPI.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
@@ -33,6 +34,7 @@ namespace CloudConvert.API
     #endregion
 
     Task<string> UploadAsync(string url, byte[] file, string fileName, object parameters);
+    Task<string> UploadAsync(string url, Stream file, string fileName, object parameters);
     bool ValidateWebhookSignatures(string payloadString, string signature, string signingSecret);
     string CreateSignedUrl(string baseUrl, string signingSecret, JobCreateRequest job, string cacheKey = null);
   }
@@ -50,13 +52,17 @@ namespace CloudConvert.API
     const string publicUrlSyncApi = "https://sync.api.cloudconvert.com/v2";
     static readonly char[] base64Padding = { '=' };
 
-
-    public CloudConvertAPI(string api_key, bool isSandbox = false)
+    internal CloudConvertAPI(RestHelper restHelper, string api_key, bool isSandbox = false)
     {
       _apiUrl = isSandbox ? sandboxUrlApi : publicUrlApi;
       _apiSyncUrl = isSandbox ? sandboxUrlSyncApi : publicUrlSyncApi;
       _api_key += api_key;
-      _restHelper = new RestHelper();
+      _restHelper = restHelper;
+    }
+
+    public CloudConvertAPI(string api_key, bool isSandbox = false)
+      : this(new RestHelper(), api_key, isSandbox)
+    {
     }
 
     public CloudConvertAPI(string url, string api_key)
@@ -82,7 +88,7 @@ namespace CloudConvert.API
       return request;
     }
 
-    private HttpRequestMessage GetMultipartFormDataRequest(string endpoint, HttpMethod method, byte[] file, string fileName, Dictionary<string, string> parameters = null)
+    private HttpRequestMessage GetMultipartFormDataRequest(string endpoint, HttpMethod method, HttpContent fileContent, string fileName, Dictionary<string, string> parameters = null)
     {
       var content = new MultipartFormDataContent();
       var request = new HttpRequestMessage { RequestUri = new Uri(endpoint), Method = method, };
@@ -95,9 +101,7 @@ namespace CloudConvert.API
         }
       }
 
-      var fileContent = new ByteArrayContent(file);
-      fileContent.Headers.Add("Content-Disposition", $"form-data; name=\"file\"; filename=\"{ new string(Encoding.UTF8.GetBytes(fileName).Select(b => (char)b).ToArray())}\"");
-      content.Add(fileContent);
+      content.Add(fileContent, "file", fileName);
 
       request.Content = content;
 
@@ -214,7 +218,24 @@ namespace CloudConvert.API
 
     #endregion
 
-    public Task<string> UploadAsync(string url, byte[] file, string fileName, object parameters) => _restHelper.RequestAsync(GetMultipartFormDataRequest($"{url}", HttpMethod.Post, file, fileName, GetParameters(parameters)));
+    public Task<string> UploadAsync(string url, byte[] file, string fileName, object parameters)
+    {
+      var content = new ByteArrayContent(file);
+      PrepareContent(content, fileName);
+      return _restHelper.RequestAsync(GetMultipartFormDataRequest(url, HttpMethod.Post, content, fileName, GetParameters(parameters)));
+    }
+
+    public Task<string> UploadAsync(string url, Stream stream, string fileName, object parameters)
+    {
+      var content = new StreamContent(stream);
+      PrepareContent(content, fileName);
+      return _restHelper.RequestAsync(GetMultipartFormDataRequest(url, HttpMethod.Post, content, fileName, GetParameters(parameters)));
+    }
+
+    private static void PrepareContent(HttpContent content, string fileName)
+    {
+      content.Headers.Add("Content-Disposition", $"form-data; name=\"file\"; filename=\"{ new string(Encoding.UTF8.GetBytes(fileName).Select(b => (char)b).ToArray())}\"");
+    }
 
     public string CreateSignedUrl(string baseUrl, string signingSecret, JobCreateRequest job, string cacheKey = null)
     {

--- a/CloudConvert.API/RestHelper.cs
+++ b/CloudConvert.API/RestHelper.cs
@@ -14,6 +14,11 @@ namespace CloudConvert.API
       _httpClient.Timeout = System.TimeSpan.FromMilliseconds(System.Threading.Timeout.Infinite);
     }
 
+    internal RestHelper(HttpClient httpClient)
+    {
+      _httpClient = httpClient;
+    }
+
     public async Task<T> RequestAsync<T>(HttpRequestMessage request)
     {
       var response = await _httpClient.SendAsync(request);

--- a/CloudConvert.Test/Extensions/MockExtensions.cs
+++ b/CloudConvert.Test/Extensions/MockExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Language.Flow;
+using Moq.Protected;
+
+namespace CloudConvert.Test.Extensions
+{
+  public static class MockExtensions
+  {
+    public static IReturnsResult<HttpMessageHandler> MockResponse(this Mock<HttpMessageHandler> mock, string endpoint, string fileName)
+    {
+      return mock.Protected()
+        .Setup<Task<HttpResponseMessage>>("SendAsync",
+          ItExpr.Is<HttpRequestMessage>(message => message.RequestUri.AbsolutePath.EndsWith(endpoint)),
+          ItExpr.IsAny<CancellationToken>())
+        .ReturnsAsync(new HttpResponseMessage
+        {
+          StatusCode = HttpStatusCode.OK,
+          Content = new StringContent(File.ReadAllText(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Responses", fileName)))
+        });
+    }
+
+    public static void VerifyRequest(this Mock<HttpMessageHandler> mock, string endpoint, Times times)
+    {
+      mock.Protected()
+        .Verify("SendAsync",
+          times,
+          ItExpr.Is<HttpRequestMessage>(message => message.RequestUri.AbsolutePath.EndsWith(endpoint)),
+          ItExpr.IsAny<CancellationToken>());
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the following method to `ICloudConvertAPI`:

```cs
interface ICloudConvertAPI
{
	Task<string> UploadAsync(string url, Stream file, string fileName, object parameters);
}
```

Currently it's only possible to send a byte-array. Because of this, you have to load the file into memory before sending it to CloudConvert. This is fine for small files but loading large files could be a memory problem.

It's noteworthy that the stream doesn't get disposed by the API, so for example:

```cs
var stream = File.Open("file.png", FileMode.Open, FileAccess.Read, FileShare.Read);

await cloudConvertApi.UploadAsync(url, stream, "file.png", parameters);
```

In this example the `stream` is still open. You'll have to `Dispose` the stream yourself (or use `using var stream = ...`).

**Tests**
I've added an internal constructor in `RestHelper` and made the internals visible to the Tests-project. This is so I can mock the HTTP-client and check if the stream doesn't get disposed by `CloudConvertAPI`.