### PR TITLE
Use System.Text.Json instead of Newtonsoft.Json

### DIFF
--- a/CloudConvert.API/CloudConvert.API.csproj
+++ b/CloudConvert.API/CloudConvert.API.csproj
@@ -18,7 +18,6 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2021.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/CloudConvert.API/DefaultJsonSerializerOptions.cs
+++ b/CloudConvert.API/DefaultJsonSerializerOptions.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace CloudConvert.API
+{
+  public class DefaultJsonSerializerOptions
+  {
+    public static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+      Converters = { new JsonStringEnumConverter() },
+      DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+  }
+}

--- a/CloudConvert.API/Models/ErrorResponse.cs
+++ b/CloudConvert.API/Models/ErrorResponse.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models
 {
   public partial class ErrorResponse
   {
-    [JsonProperty("message")]
+    [JsonPropertyName("message")]
     public string Message { get; set; }
 
-    [JsonProperty("code")]
+    [JsonPropertyName("code")]
     public string Code { get; set; }
 
-    [JsonProperty("errors")]
+    [JsonPropertyName("errors")]
     public object Errors { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ExportOperations/ExportAzureBlobCreateRequest.cs
+++ b/CloudConvert.API/Models/ExportOperations/ExportAzureBlobCreateRequest.cs
@@ -1,35 +1,35 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.ExportOperations
 {
   public class ExportAzureBlobCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "export/azure/blob";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "export/azure/blob";
 
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
-    [JsonProperty("storage_account")]
+    [JsonPropertyName("storage_account")]
     public string Storage_Account { get; set; }
 
-    [JsonProperty("storage_access_key", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("storage_access_key")]
     public string Storage_Access_Key { get; set; }
 
-    [JsonProperty("sas_token", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("sas_token")]
     public string Sas_Token { get; set; }
 
-    [JsonProperty("container")]
+    [JsonPropertyName("container")]
     public string Container { get; set; }
 
-    [JsonProperty("blob", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("blob")]
     public string Blob { get; set; }
 
-    [JsonProperty("blob_prefix", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("blob_prefix")]
     public string Blob_Prefix { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ExportOperations/ExportGoogleCloudStorageCreateRequest.cs
+++ b/CloudConvert.API/Models/ExportOperations/ExportGoogleCloudStorageCreateRequest.cs
@@ -1,35 +1,35 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.ExportOperations
 {
   public class ExportGoogleCloudStorageCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "export/google-cloud-storage";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "export/google-cloud-storage";
 
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
-    [JsonProperty("project_id")]
+    [JsonPropertyName("project_id")]
     public string ProjectId { get; set; }
 
-    [JsonProperty("bucket")]
+    [JsonPropertyName("bucket")]
     public string Bucket { get; set; }
 
-    [JsonProperty("client_email")]
+    [JsonPropertyName("client_email")]
     public string Client_Email { get; set; }
 
-    [JsonProperty("private_key")]
+    [JsonPropertyName("private_key")]
     public string Private_Key { get; set; }
 
-    [JsonProperty("file", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("file")]
     public string File { get; set; }
 
-    [JsonProperty("file_prefix", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("file_prefix")]
     public string File_Prefix { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ExportOperations/ExportOpenStackCreateRequest.cs
+++ b/CloudConvert.API/Models/ExportOperations/ExportOpenStackCreateRequest.cs
@@ -1,38 +1,38 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.ExportOperations
 {
   public class ExportOpenStackCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "export/openstack";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "export/openstack";
 
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
-    [JsonProperty("auth_url")]
+    [JsonPropertyName("auth_url")]
     public string Auth_Url { get; set; }
 
-    [JsonProperty("username")]
+    [JsonPropertyName("username")]
     public string Username { get; set; }
 
-    [JsonProperty("password")]
+    [JsonPropertyName("password")]
     public string Password { get; set; }
 
-    [JsonProperty("region")]
+    [JsonPropertyName("region")]
     public string Region { get; set; }
 
-    [JsonProperty("container")]
+    [JsonPropertyName("container")]
     public string Container { get; set; }
 
-    [JsonProperty("file", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("file")]
     public string File { get; set; }
 
-    [JsonProperty("file_prefix", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("file_prefix")]
     public string FilePrefix { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ExportOperations/ExportS3CreateRequest.cs
+++ b/CloudConvert.API/Models/ExportOperations/ExportS3CreateRequest.cs
@@ -1,90 +1,88 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 using CloudConvert.API.Models.Enums;
 
 namespace CloudConvert.API.Models.ExportOperations
 {
   public class ExportS3CreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "export/s3";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "export/s3";
 
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
     /// <summary>
     /// The Amazon S3 bucket where to store the file(s).
     /// </summary>
-    [JsonProperty("bucket")]
+    [JsonPropertyName("bucket")]
     public string Bucket { get; set; }
 
     /// <summary>
     /// Specify the Amazon S3 endpoint, e.g. us-west-2 or eu-west-1.
     /// </summary>
-    [JsonProperty("region")]
+    [JsonPropertyName("region")]
     public string Region { get; set; }
 
-    [JsonProperty("endpoint", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("endpoint")]
     public string Endpoint { get; set; }
 
     /// <summary>
     /// S3 key for storing the file (the filename in the bucket, including path).
     /// </summary>
-    [JsonProperty("key", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("key")]
     public string Key { get; set; }
 
     /// <summary>
     /// Alternatively to using key, you can specify a key prefix for exporting files.
     /// </summary>
-    [JsonProperty("key_prefix", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("key_prefix")]
     public string Key_Prefix { get; set; }
 
     /// <summary>
     /// The Amazon S3 access key id.
     /// </summary>
-    [JsonProperty("access_key_id")]
+    [JsonPropertyName("access_key_id")]
     public string Access_Key_Id { get; set; }
 
     /// <summary>
     /// The Amazon S3 secret access key.
     /// </summary>
-    [JsonProperty("secret_access_key")]
+    [JsonPropertyName("secret_access_key")]
     public string Secret_Access_Key { get; set; }
 
     /// <summary>
     /// Auth using temporary credentials.
     /// </summary>
-    [JsonProperty("session_token", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("session_token")]
     public string Session_Token { get; set; }
 
     /// <summary>
     /// S3 ACL for storing the files.
     /// </summary>
-    [JsonProperty("acl", NullValueHandling = NullValueHandling.Ignore)]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonPropertyName("acl")]
     public ExportS3Acl? Acl { get; set; }
 
     /// <summary>
     /// S3 CacheControl header to specify the lifetime of the file.
     /// </summary>
-    [JsonProperty("cache_control", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("cache_control")]
     public string Cache_Control { get; set; }
 
     /// <summary>
     /// Object of additional S3 meta data.
     /// </summary>
-    [JsonProperty("metadata", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("metadata")]
     public Dictionary<string, string> Metadata { get; set; }
 
     /// <summary>
     /// Enable the Server-side encryption algorithm used when storing this object in S3.
     /// </summary>
-    [JsonProperty("server_side_encryption", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("server_side_encryption")]
     public string Server_Side_Encryption { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ExportOperations/ExportSFTPCreateRequest.cs
+++ b/CloudConvert.API/Models/ExportOperations/ExportSFTPCreateRequest.cs
@@ -1,37 +1,38 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.ExportOperations
 {
   public class ExportSFTPCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "export/sftp";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "export/sftp";
+
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
-    [JsonProperty("host")]
+    [JsonPropertyName("host")]
     public string Host { get; set; }
 
-    [JsonProperty("port", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("port")]
     public string Port { get; set; }
 
-    [JsonProperty("username")]
+    [JsonPropertyName("username")]
     public string Username { get; set; }
 
-    [JsonProperty("password", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("password")]
     public string Password { get; set; }
 
-    [JsonProperty("private_key", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("private_key")]
     public string Private_Key { get; set; }
 
-    [JsonProperty("file", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("file")]
     public string File { get; set; }
 
-    [JsonProperty("path", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("path")]
     public string Path { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ExportOperations/ExportUrlCreateRequest.cs
+++ b/CloudConvert.API/Models/ExportOperations/ExportUrlCreateRequest.cs
@@ -1,32 +1,32 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.ExportOperations
 {
   public class ExportUrlCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "export/url";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "export/url";
 
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
     /// <summary>
     /// This option makes the export URLs return the Content-Disposition inline header, which tells browser to display the file instead of downloading it.
     /// </summary>
-    [JsonProperty("inline", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("inline")]
     public bool? Inline { get; set; }
 
-    [JsonProperty("inline_additional", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("inline_additional")]
     public bool? Inline_Additional { get; set; }
 
     /// <summary>
     /// By default, multiple files will create multiple export URLs. When enabling this option, one export URL with a ZIP file will be created.
     /// </summary>
-    [JsonProperty("archive_multiple_files", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("archive_multiple_files")]
     public bool? Archive_Multiple_Files { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ImportOperations/ImportAzureBlobCreateRequest.cs
+++ b/CloudConvert.API/Models/ImportOperations/ImportAzureBlobCreateRequest.cs
@@ -1,31 +1,31 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.ImportOperations
 {
   public class ImportAzureBlobCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "import/azure/blob";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "import/azure/blob";
 
-    [JsonProperty("storage_account")]
+    [JsonPropertyName("storage_account")]
     public string Storage_Account { get; set; }
 
-    [JsonProperty("storage_access_key", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("storage_access_key")]
     public string Storage_Access_Key { get; set; }
 
-    [JsonProperty("sas_token", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("sas_token")]
     public string Sas_Token { get; set; }
 
-    [JsonProperty("container")]
+    [JsonPropertyName("container")]
     public string Container { get; set; }
 
-    [JsonProperty("blob", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("blob")]
     public string Blob { get; set; }
 
-    [JsonProperty("blob_prefix", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("blob_prefix")]
     public string Blob_Prefix { get; set; }
 
-    [JsonProperty("filename", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ImportOperations/ImportGoogleCloudStorageCreateRequest.cs
+++ b/CloudConvert.API/Models/ImportOperations/ImportGoogleCloudStorageCreateRequest.cs
@@ -1,32 +1,31 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.ImportOperations
 {
   public class ImportGoogleCloudStorageCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "import/google-cloud-storage";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "import/google-cloud-storage";
 
-    [JsonProperty("project_id")]
+    [JsonPropertyName("project_id")]
     public string Project_Id { get; set; }
 
-    [JsonProperty("bucket")]
+    [JsonPropertyName("bucket")]
     public string Bucket { get; set; }
 
-    [JsonProperty("client_email")]
+    [JsonPropertyName("client_email")]
     public string Client_Email { get; set; }
 
-    [JsonProperty("private_key")]
+    [JsonPropertyName("private_key")]
     public string Private_Key { get; set; }
 
-    [JsonProperty("file", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("file")]
     public string File { get; set; }
 
-    [JsonProperty("file_prefix", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("file_prefix")]
     public string File_Prefix { get; set; }
 
-    [JsonProperty("filename", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
-
   }
 }

--- a/CloudConvert.API/Models/ImportOperations/ImportOpenStackCreateRequest.cs
+++ b/CloudConvert.API/Models/ImportOperations/ImportOpenStackCreateRequest.cs
@@ -1,34 +1,34 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.ImportOperations
 {
   public class ImportOpenStackCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "import/openstack";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "import/openstack";
 
-    [JsonProperty("auth_url")]
+    [JsonPropertyName("auth_url")]
     public string Auth_Url { get; set; }
 
-    [JsonProperty("username")]
+    [JsonPropertyName("username")]
     public string Username { get; set; }
 
-    [JsonProperty("password")]
+    [JsonPropertyName("password")]
     public string Password { get; set; }
 
-    [JsonProperty("region")]
+    [JsonPropertyName("region")]
     public string Region { get; set; }
 
-    [JsonProperty("container")]
+    [JsonPropertyName("container")]
     public string Container { get; set; }
 
-    [JsonProperty("file", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("file")]
     public string File { get; set; }
 
-    [JsonProperty("file_prefix", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("file_prefix")]
     public string File_Prefix { get; set; }
 
-    [JsonProperty("filename", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ImportOperations/ImportS3CreateRequest.cs
+++ b/CloudConvert.API/Models/ImportOperations/ImportS3CreateRequest.cs
@@ -1,58 +1,58 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.ImportOperations
 {
   public class ImportS3CreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "import/s3";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "import/s3";
 
     /// <summary>
     /// The Amazon S3 bucket where to download the file.
     /// </summary>
-    [JsonProperty("bucket")]
+    [JsonPropertyName("bucket")]
     public string Bucket { get; set; }
 
     /// <summary>
     /// Specify the Amazon S3 endpoint, e.g. us-west-2 or eu-west-1.
     /// </summary>
-    [JsonProperty("region")]
+    [JsonPropertyName("region")]
     public string Region { get; set; }
 
-    [JsonProperty("endpoint", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("endpoint")]
     public string Endpoint { get; set; }
 
     /// <summary>
     /// S3 key of the input file (the filename in the bucket, including path).
     /// </summary>
-    [JsonProperty("key", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("key")]
     public string Key { get; set; }
 
     /// <summary>
     /// Alternatively to using key, you can specify a key prefix for importing multiple files.
     /// </summary>
-    [JsonProperty("key_prefix", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("key_prefix")]
     public string Key_Prefix { get; set; }
 
     /// <summary>
     /// The Amazon S3 access key id.
     /// </summary>
-    [JsonProperty("access_key_id")]
+    [JsonPropertyName("access_key_id")]
     public string Access_Key_Id { get; set; }
 
     /// <summary>
     /// The Amazon S3 secret access key.
     /// </summary>
-    [JsonProperty("secret_access_key")]
+    [JsonPropertyName("secret_access_key")]
     public string Secret_Access_Key { get; set; }
 
     /// <summary>
     /// Auth using temporary credentials.
     /// </summary>
-    [JsonProperty("session_token", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("session_token")]
     public string Session_Token { get; set; }
 
-    [JsonProperty("filename", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ImportOperations/ImportSFTPCreateRequest.cs
+++ b/CloudConvert.API/Models/ImportOperations/ImportSFTPCreateRequest.cs
@@ -1,34 +1,34 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.ImportOperations
 {
   public class ImportSFTPCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "import/sftp";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "import/sftp";
 
-    [JsonProperty("host")]
+    [JsonPropertyName("host")]
     public string Host { get; set; }
 
-    [JsonProperty("port", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("port")]
     public string Port { get; set; }
 
-    [JsonProperty("username")]
+    [JsonPropertyName("username")]
     public string Username { get; set; }
 
-    [JsonProperty("password", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("password")]
     public string Password { get; set; }
 
-    [JsonProperty("private_key", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("private_key")]
     public string Private_Key { get; set; }
 
-    [JsonProperty("file", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("file")]
     public string File { get; set; }
 
-    [JsonProperty("path", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("path")]
     public string Path { get; set; }
 
-    [JsonProperty("filename", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ImportOperations/ImportUploadCreateRequest.cs
+++ b/CloudConvert.API/Models/ImportOperations/ImportUploadCreateRequest.cs
@@ -1,16 +1,16 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.ImportOperations
 {
   public class ImportUploadCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "import/upload";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "import/upload";
 
     /// <summary>
     /// Redirect user to this URL after upload
     /// </summary>
-    [JsonProperty("redirect", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("redirect")]
     public string Redirect { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ImportOperations/ImportUrlCreateRequest.cs
+++ b/CloudConvert.API/Models/ImportOperations/ImportUrlCreateRequest.cs
@@ -1,24 +1,23 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.ImportOperations
 {
   public class ImportUrlCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "import/url";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "import/url";
 
-    [JsonProperty("url")]
+    [JsonPropertyName("url")]
     public string Url { get; set; }
 
     /// <summary>
     /// The filename of the input file, including extension. If none provided we will try to detect the filename from the URL.
     /// </summary>
-    [JsonProperty("filename", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
 
-    [JsonProperty("headers", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("headers")]
     public Dictionary<string, string> Headers { get; set; }
-
   }
 }

--- a/CloudConvert.API/Models/JobModels/JobCreateRequest.cs
+++ b/CloudConvert.API/Models/JobModels/JobCreateRequest.cs
@@ -1,4 +1,4 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.JobModels
 {
@@ -8,17 +8,17 @@ namespace CloudConvert.API.Models.JobModels
     /// The example on the right consists of three tasks: import-my-file, convert-my-file and export-my-file. 
     /// You can name these tasks however you want, but only alphanumeric characters, - and _ are allowed in the task names.
     /// 
-    /// Each task has a operation, which is the endpoint for creating the task(for example: convert, import/s3 or export/s3). 
+    /// Each task has an operation, which is the endpoint for creating the task (for example: convert, import/s3 or export/s3).
     /// The other parameters are the same as for creating the task using their direct endpoint.
     /// The input parameter allows it to directly reference the name of another task, created with the same job request.
     /// </summary>
-    [JsonProperty("tasks")]
-    public dynamic Tasks { get; set; }
+    [JsonPropertyName("tasks")]
+    public object Tasks { get; set; }
 
     /// <summary>
     /// An arbitrary string to identify the job. Does not have any effect and can be used to associate the job with an ID in your application.
     /// </summary>
-    [JsonProperty("tag")]
+    [JsonPropertyName("tag")]
     public string Tag { get; set; }
   }
 }

--- a/CloudConvert.API/Models/JobModels/JobResponse.cs
+++ b/CloudConvert.API/Models/JobModels/JobResponse.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using CloudConvert.API.Models.TaskModels;
 
 namespace CloudConvert.API.Models.JobModels
@@ -10,46 +10,46 @@ namespace CloudConvert.API.Models.JobModels
     /// <summary>
     /// The ID of the job.
     /// </summary>
-    [JsonProperty("id")]
+    [JsonPropertyName("id")]
     public string Id { get; set; }
 
     /// <summary>
     /// Your given tag of the job.
     /// </summary>
-    [JsonProperty("tag")]
+    [JsonPropertyName("tag")]
     public string Tag { get; set; }
 
     /// <summary>
     /// The status of the job. Is one of processing, finished or error.
     /// </summary>
-    [JsonProperty("status")]
+    [JsonPropertyName("status")]
     public string Status { get; set; }
 
     /// <summary>
     /// ISO8601 timestamp of the creation of the job.
     /// </summary>
-    [JsonProperty("created_at")]
+    [JsonPropertyName("created_at")]
     public DateTimeOffset? Created_At { get; set; }
 
     /// <summary>
     /// ISO8601 timestamp when the job started processing.
     /// </summary>
-    [JsonProperty("started_at")]
+    [JsonPropertyName("started_at")]
     public DateTimeOffset? Started_At { get; set; }
 
     /// <summary>
     /// ISO8601 timestamp when the job finished or failed.
     /// </summary>
-    [JsonProperty("ended_at")]
+    [JsonPropertyName("ended_at")]
     public DateTimeOffset? Ended_At { get; set; }
 
     /// <summary>
     /// List of tasks that are part of the job. You can find details about the task model response in the documentation about the show tasks endpoint.
     /// </summary>
-    [JsonProperty("tasks")]
+    [JsonPropertyName("tasks")]
     public List<TaskResponse> Tasks { get; set; }
 
-    [JsonProperty("links")]
+    [JsonPropertyName("links")]
     public ResponseLinks Links { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ListResponse.cs
+++ b/CloudConvert.API/Models/ListResponse.cs
@@ -1,17 +1,17 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models
 {
   public partial class ListResponse<T>
   {
-    [JsonProperty("data")]
+    [JsonPropertyName("data")]
     public List<T> Data { get; set; }
 
-    [JsonProperty("links")]
+    [JsonPropertyName("links")]
     public ListResponseLinks Links { get; set; }
 
-    [JsonProperty("meta")]
+    [JsonPropertyName("meta")]
     public ListResponseMeta Meta { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ListResponseLinks.cs
+++ b/CloudConvert.API/Models/ListResponseLinks.cs
@@ -1,20 +1,20 @@
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models
 {
   public partial class ListResponseLinks
   {
-    [JsonProperty("first")]
+    [JsonPropertyName("first")]
     public Uri First { get; set; }
 
-    [JsonProperty("last")]
+    [JsonPropertyName("last")]
     public Uri Last { get; set; }
 
-    [JsonProperty("prev")]
+    [JsonPropertyName("prev")]
     public Uri Prev { get; set; }
 
-    [JsonProperty("next")]
+    [JsonPropertyName("next")]
     public Uri Next { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ListResponseMeta.cs
+++ b/CloudConvert.API/Models/ListResponseMeta.cs
@@ -1,23 +1,23 @@
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models
 {
   public partial class ListResponseMeta
   {
-    [JsonProperty("current_page")]
+    [JsonPropertyName("current_page")]
     public int? Current_Page { get; set; }
 
-    [JsonProperty("from")]
+    [JsonPropertyName("from")]
     public int? From { get; set; }
 
-    [JsonProperty("path")]
+    [JsonPropertyName("path")]
     public Uri Path { get; set; }
 
-    [JsonProperty("per_page")]
+    [JsonPropertyName("per_page")]
     public int? Per_Page { get; set; }
 
-    [JsonProperty("to")]
+    [JsonPropertyName("to")]
     public int? To { get; set; }
   }
 }

--- a/CloudConvert.API/Models/Response.cs
+++ b/CloudConvert.API/Models/Response.cs
@@ -1,10 +1,10 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models
 {
   public partial class Response<T>
   {
-    [JsonProperty("data")]
+    [JsonPropertyName("data")]
     public T Data { get; set; }
   }
 }

--- a/CloudConvert.API/Models/ResponseLinks.cs
+++ b/CloudConvert.API/Models/ResponseLinks.cs
@@ -1,11 +1,11 @@
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models
 {
   public partial class ResponseLinks
   {
-    [JsonProperty("self")]
+    [JsonPropertyName("self")]
     public Uri Self { get; set; }
   }
 }

--- a/CloudConvert.API/Models/TaskModels/TaskResponse.cs
+++ b/CloudConvert.API/Models/TaskModels/TaskResponse.cs
@@ -1,7 +1,7 @@
 using System;
-using Newtonsoft.Json;
-using CloudConvert.API.Models.Enums;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using CloudConvert.API.Models.Enums;
 
 namespace CloudConvert.API.Models.TaskModels
 {
@@ -10,131 +10,131 @@ namespace CloudConvert.API.Models.TaskModels
     /// <summary>
     /// The ID of the task.
     /// </summary>
-    [JsonProperty("id")]
+    [JsonPropertyName("id")]
     public string Id { get; set; }
 
     /// <summary>
-    /// The Job ID the tasks belongs to.
+    /// The Job ID the task belongs to.
     /// </summary>
-    [JsonProperty("job_id")]
+    [JsonPropertyName("job_id")]
     public string Job_Id { get; set; }
 
-    [JsonProperty("name")]
+    [JsonPropertyName("name")]
     public string Name { get; set; }
 
     /// <summary>
     /// Name of the operation, for example convert or import/s3.
     /// </summary>
-    [JsonProperty("operation")]
+    [JsonPropertyName("operation")]
     public string Operation { get; set; }
 
     /// <summary>
     /// The status of the task. Is one of waiting, processing, finished or error.
     /// </summary>
-    [JsonProperty("status")]
+    [JsonPropertyName("status")]
     public TaskStatus Status { get; set; }
 
     /// <summary>
     /// The amount of conversion minutes the task consumed. Available when the status is finished.
     /// </summary>
-    [JsonProperty("credits")]
+    [JsonPropertyName("credits")]
     public int? Credits { get; set; }
 
     /// <summary>
     /// The status message. Contains the error message if the task status is error.
     /// </summary>
-    [JsonProperty("message")]
+    [JsonPropertyName("message")]
     public object Message { get; set; }
 
     /// <summary>
     /// The error code if the task status is error.
     /// </summary>
-    [JsonProperty("code")]
+    [JsonPropertyName("code")]
     public string Code { get; set; }
 
-    [JsonProperty("percent")]
+    [JsonPropertyName("percent")]
     public int Percent { get; set; }
 
     /// <summary>
     /// ISO8601 timestamp of the creation of the task.
     /// </summary>
-    [JsonProperty("created_at")]
+    [JsonPropertyName("created_at")]
     public DateTimeOffset? Created_At { get; set; }
 
     /// <summary>
     /// ISO8601 timestamp when the task started processing.
     /// </summary>
-    [JsonProperty("started_at")]
+    [JsonPropertyName("started_at")]
     public DateTimeOffset? Started_At { get; set; }
 
     /// <summary>
     /// ISO8601 timestamp when the task finished or failed.
     /// </summary>
-    [JsonProperty("ended_at")]
+    [JsonPropertyName("ended_at")]
     public DateTimeOffset? Ended_At { get; set; }
 
     /// <summary>
     /// List of tasks that are dependencies for this task. Only available if the include parameter was set to depends_on_tasks.
     /// </summary>
-    [JsonProperty("depends_on_tasks")]
+    [JsonPropertyName("depends_on_tasks")]
     public object Depends_On_Tasks { get; set; }
 
-    [JsonProperty("depends_on_task_ids")]
+    [JsonPropertyName("depends_on_task_ids")]
     public List<string> Depends_On_Task_Ids { get; set; }
 
     /// <summary>
     /// ID of the original task, if this task is a retry.
     /// </summary>
-    [JsonProperty("retry_of_task_id")]
+    [JsonPropertyName("retry_of_task_id")]
     public string Retry_Of_Task_Id { get; set; }
 
-    [JsonProperty("copy_of_task_id")]
+    [JsonPropertyName("copy_of_task_id")]
     public object Copy_Of_Task_Id { get; set; }
 
-    [JsonProperty("user_id")]
+    [JsonPropertyName("user_id")]
     public int User_Id { get; set; }
 
-    [JsonProperty("priority")]
+    [JsonPropertyName("priority")]
     public long Priority { get; set; }
 
-    [JsonProperty("host_name")]
+    [JsonPropertyName("host_name")]
     public object Host_Name { get; set; }
 
-    [JsonProperty("storage")]
+    [JsonPropertyName("storage")]
     public string Storage { get; set; }
 
     /// <summary>
     /// List of tasks that are retries of this task. Only available if the include parameter was set to retries.
     /// </summary>
-    [JsonProperty("retries")]
+    [JsonPropertyName("retries")]
     public string Retries { get; set; }
 
     /// <summary>
     /// Name of the engine.
     /// </summary>
-    [JsonProperty("engine")]
+    [JsonPropertyName("engine")]
     public string Engine { get; set; }
 
     /// <summary>
     /// Version of the engine.
     /// </summary>
-    [JsonProperty("engine_version")]
+    [JsonPropertyName("engine_version")]
     public string Engine_Version { get; set; }
 
     /// <summary>
     /// Your submitted payload for the tasks. Depends on the operation type.
     /// </summary>
-    [JsonProperty("payload")]
+    [JsonPropertyName("payload")]
     public object Payload { get; set; }
 
     /// <summary>
     /// The result of the task. Depends on the operation type. 
     /// Finished tasks always do have a files key with the names of the result files of the task (See the example on the right).
     /// </summary>
-    [JsonProperty("result")]
+    [JsonPropertyName("result")]
     public TaskResult Result { get; set; }
-  
-    [JsonProperty("links")]
+
+    [JsonPropertyName("links")]
     public ResponseLinks Links { get; set; }
   }
 }

--- a/CloudConvert.API/Models/TaskModels/TaskResult.cs
+++ b/CloudConvert.API/Models/TaskModels/TaskResult.cs
@@ -1,17 +1,17 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.TaskModels
 {
   public partial class TaskResult
   {
-    [JsonProperty("form")]
+    [JsonPropertyName("form")]
     public UploadForm Form { get; set; }
 
-    [JsonProperty("files")]
+    [JsonPropertyName("files")]
     public List<TaskResultFile> Files { get; set; }
 
-    [JsonProperty("metadata")]
+    [JsonPropertyName("metadata")]
     public Dictionary<string, object> Metadata { get; set; }
   }
 }

--- a/CloudConvert.API/Models/TaskModels/TaskResultFile.cs
+++ b/CloudConvert.API/Models/TaskModels/TaskResultFile.cs
@@ -1,17 +1,17 @@
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.TaskModels
 {
   public partial class TaskResultFile
   {
-    [JsonProperty("filename")]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
 
-    [JsonProperty("size")]
+    [JsonPropertyName("size")]
     public long Size { get; set; }
 
-    [JsonProperty("url")]
+    [JsonPropertyName("url")]
     public Uri Url { get; set; }
   }
 }

--- a/CloudConvert.API/Models/TaskModels/UploadForm.cs
+++ b/CloudConvert.API/Models/TaskModels/UploadForm.cs
@@ -1,14 +1,14 @@
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.TaskModels
 {
   public partial class UploadForm
   {
-    [JsonProperty("url")]
+    [JsonPropertyName("url")]
     public Uri Url { get; set; }
 
-    [JsonProperty("parameters")]
+    [JsonPropertyName("parameters")]
     public object Parameters { get; set; }
   }
 }

--- a/CloudConvert.API/Models/TaskOperations/ArchiveCreateRequest.cs
+++ b/CloudConvert.API/Models/TaskOperations/ArchiveCreateRequest.cs
@@ -1,38 +1,38 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.TaskOperations
 {
   public class ArchiveCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "archive";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "archive";
 
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
-    [JsonProperty("output_format")]
+    [JsonPropertyName("output_format")]
     public string Output_Format { get; set; }
 
-    [JsonProperty("engine", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine")]
     public string Engine { get; set; }
 
-    [JsonProperty("engine_version", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine_version")]
     public string Engine_Version { get; set; }
 
     /// <summary>
     /// Choose a filename (including extension) for the output file.
     /// </summary>
-    [JsonProperty("filename", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
 
     /// <summary>
     /// Timeout in seconds after the task will be cancelled.
     /// </summary>
-    [JsonProperty("timeout", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("timeout")]
     public int? Timeout { get; set; }
   }
 }

--- a/CloudConvert.API/Models/TaskOperations/CaptureCreateRequest.cs
+++ b/CloudConvert.API/Models/TaskOperations/CaptureCreateRequest.cs
@@ -1,98 +1,95 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 using CloudConvert.API.Models.Enums;
 
 namespace CloudConvert.API.Models.TaskOperations
 {
   public class CaptureWebsiteCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "capture-website";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "capture-website";
 
     /// <summary>
     /// URL of the website
     /// </summary>
-    [JsonProperty("url")]
+    [JsonPropertyName("url")]
     public string Url { get; set; }
 
-    [JsonProperty("output_format")]
+    [JsonPropertyName("output_format")]
     public string Output_Format { get; set; }
 
-    [JsonProperty("engine", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine")]
     public string Engine { get; set; }
 
-    [JsonProperty("engine_version", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine_version")]
     public string Engine_Version { get; set; }
 
     /// <summary>
     /// Choose a filename(including extension) for the output file.
     /// </summary>
-    [JsonProperty("filename", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
 
-    [JsonProperty("pages", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("pages")]
     public string Pages { get; set; }
 
-    [JsonProperty("zoom", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("zoom")]
     public int? Zoom { get; set; }
 
-    [JsonProperty("page_width", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("page_width")]
     public int? Page_Width { get; set; }
 
-
-    [JsonProperty("page_height", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("page_height")]
     public int? Page_Height { get; set; }
 
-    [JsonProperty("margin_top", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("margin_top")]
     public int? Margin_Top { get; set; }
 
-    [JsonProperty("margin_bottom", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("margin_bottom")]
     public int? Margin_Bottom { get; set; }
 
-    [JsonProperty("margin_left", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("margin_left")]
     public int? Margin_Left { get; set; }
 
-    [JsonProperty("margin_right", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("margin_right")]
     public int? Margin_Right { get; set; }
 
-    [JsonProperty("print_background", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("print_background")]
     public bool? Print_Background { get; set; }
 
-    [JsonProperty("display_header_footer", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("display_header_footer")]
     public bool? Display_Header_Footer { get; set; }
 
-    [JsonProperty("header_template", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("header_template")]
     public string Header_Template { get; set; }
 
-    [JsonProperty("footer_template", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("footer_template")]
     public string Footer_Template { get; set; }
 
-    [JsonProperty("wait_until", NullValueHandling = NullValueHandling.Ignore)]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonPropertyName("wait_until")]
     public CaptureWebsiteWaitUntil? Wait_Until { get; set; }
 
-    [JsonProperty("wait_for_element", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("wait_for_element")]
     public string Wait_For_Element { get; set; }
 
-    [JsonProperty("wait_time", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("wait_time")]
     public int? Wait_Time { get; set; }
 
-    [JsonProperty("headers", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("headers")]
     public Dictionary<string, string> Headers { get; set; }
 
     /// <summary>
     /// Timeout in seconds after the task will be cancelled.
     /// </summary>
-    [JsonProperty("timeout", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("timeout")]
     public int? Timeout { get; set; }
 
     /// <summary>
-    /// Conversion and engine specific options. Depends on input_format and output_format.
+    /// Conversion and engine-specific options. Depends on input_format and output_format.
     /// Select input and output format above to show additional conversion options.
     /// </summary>
     [JsonExtensionData]
-    [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("options")]
     public Dictionary<string, object> Options { get; set; }
   }
 }

--- a/CloudConvert.API/Models/TaskOperations/CommandCreateRequest.cs
+++ b/CloudConvert.API/Models/TaskOperations/CommandCreateRequest.cs
@@ -1,41 +1,41 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.TaskOperations
 {
   public class CommandCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "command";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "command";
 
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
-    [JsonProperty("engine", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine")]
     public string Engine { get; set; }
 
-    [JsonProperty("engine_version", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine_version")]
     public string Engine_Version { get; set; }
 
     /// <summary>
     /// Capture the console output of the command and return it in the results object.
     /// </summary>
-    [JsonProperty("capture_output", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("capture_output")]
     public bool? Capture_Output { get; set; }
 
-    [JsonProperty("command", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("command")]
     public string Command { get; set; }
 
-    [JsonProperty("arguments", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("arguments")]
     public string Arguments { get; set; }
 
     /// <summary>
     /// Timeout in seconds after the task will be cancelled.
     /// </summary>
-    [JsonProperty("timeout", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("timeout")]
     public int? Timeout { get; set; }
   }
 }

--- a/CloudConvert.API/Models/TaskOperations/ConvertCreateRequest.cs
+++ b/CloudConvert.API/Models/TaskOperations/ConvertCreateRequest.cs
@@ -1,44 +1,45 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.TaskOperations
 {
   public class ConvertCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "convert";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "convert";
+
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
     /// <summary>
     /// If not set, the extension of the input file is used as input format
     /// </summary>
-    [JsonProperty("input_format", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("input_format")]
     public string Input_Format { get; set; }
 
-    [JsonProperty("output_format")]
+    [JsonPropertyName("output_format")]
     public string Output_Format { get; set; }
 
-    [JsonProperty("engine", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine")]
     public string Engine { get; set; }
 
-    [JsonProperty("engine_version", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine_version")]
     public string Engine_Version { get; set; }
 
     /// <summary>
     /// Choose a filename (including extension) for the output file.
     /// </summary>
-    [JsonProperty("filename", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
 
     /// <summary>
     /// Timeout in seconds after the task will be cancelled.
     /// </summary>
-    [JsonProperty("timeout", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("timeout")]
     public int? Timeout { get; set; }
 
     /// <summary>
@@ -46,8 +47,7 @@ namespace CloudConvert.API.Models.TaskOperations
     /// Select input and output format above to show additional conversion options.
     /// </summary>
     [JsonExtensionData]
-    [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("options")]
     public Dictionary<string, object> Options { get; set; }
-
   }
 }

--- a/CloudConvert.API/Models/TaskOperations/MergeCreateRequest.cs
+++ b/CloudConvert.API/Models/TaskOperations/MergeCreateRequest.cs
@@ -1,41 +1,39 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 using CloudConvert.API.Models.Enums;
 
 namespace CloudConvert.API.Models.TaskOperations
 {
   public class MergeCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "merge";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "merge";
 
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
-    [JsonProperty("output_format")]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonPropertyName("output_format")]
     public MergeOutputFormat Output_Format { get; set; }
 
-    [JsonProperty("engine", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine")]
     public string Engine { get; set; }
 
-    [JsonProperty("engine_version", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine_version")]
     public string Engine_Version { get; set; }
 
     /// <summary>
     /// Choose a filename (including extension) for the output file.
     /// </summary>
-    [JsonProperty("filename", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
 
     /// <summary>
     /// Timeout in seconds after the task will be cancelled.
     /// </summary>
-    [JsonProperty("timeout", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("timeout")]
     public int? Timeout { get; set; }
   }
 }

--- a/CloudConvert.API/Models/TaskOperations/MetadataCreateRequest.cs
+++ b/CloudConvert.API/Models/TaskOperations/MetadataCreateRequest.cs
@@ -1,37 +1,40 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.TaskOperations
 {
   public class MetadataCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "metadata";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "metadata";
 
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
     /// <summary>
     /// If not set, the extension of the input file is used as input format
     /// </summary>
-    [JsonProperty("input_format", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("input_format")]
     public string Input_Format { get; set; }
 
-    [JsonProperty("engine", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine")]
     public string Engine { get; set; }
 
-    [JsonProperty("engine_version", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine_version")]
     public string Engine_Version { get; set; }
 
-    [JsonProperty("timeout", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("timeout")]
     public int? Timeout { get; set; }
 
+    /// <summary>
+    /// Conversion and engine specific options. Depends on input_format and output_format.
+    /// </summary>
     [JsonExtensionData]
-    [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("options")]
     public Dictionary<string, object> Options { get; set; }
   }
 }

--- a/CloudConvert.API/Models/TaskOperations/MetadataWriteCreateRequest.cs
+++ b/CloudConvert.API/Models/TaskOperations/MetadataWriteCreateRequest.cs
@@ -1,40 +1,43 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.TaskOperations
 {
   public class MetadataWriteCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "metadata/write";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "metadata/write";
 
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
     /// <summary>
     /// If not set, the extension of the input file is used as input format
     /// </summary>
-    [JsonProperty("input_format", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("input_format")]
     public string Input_Format { get; set; }
 
-    [JsonProperty("engine", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine")]
     public string Engine { get; set; }
 
-    [JsonProperty("engine_version", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine_version")]
     public string Engine_Version { get; set; }
 
-    [JsonProperty("timeout", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("timeout")]
     public int? Timeout { get; set; }
 
-    [JsonProperty("metadata", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("metadata")]
     public Dictionary<string, string> Metadata { get; set; }
 
+    /// <summary>
+    /// Conversion and engine specific options. Depends on input_format and output_format.
+    /// </summary>
     [JsonExtensionData]
-    [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("options")]
     public Dictionary<string, object> Options { get; set; }
   }
 }

--- a/CloudConvert.API/Models/TaskOperations/OptimizeCreateRequest.cs
+++ b/CloudConvert.API/Models/TaskOperations/OptimizeCreateRequest.cs
@@ -1,56 +1,56 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 using CloudConvert.API.Models.Enums;
 
 namespace CloudConvert.API.Models.TaskOperations
 {
   public class OptimizeCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "optimize";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "optimize";
 
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
     /// <summary>
     /// If not set, the extension of the input file is used as input format
     /// </summary>
-    [JsonConverter(typeof(StringEnumConverter))]
-    [JsonProperty("input_format", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("input_format")]
     public OptimizeInputFormat? Input_Format { get; set; }
 
-    [JsonProperty("engine", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine")]
     public string Engine { get; set; }
 
-    [JsonProperty("engine_version", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine_version")]
     public string Engine_Version { get; set; }
 
     /// <summary>
     /// Choose a filename (including extension) for the output file.
     /// </summary>
-    [JsonProperty("filename", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
 
-    [JsonProperty("quality", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("quality")]
     public int? Quality { get; set; }
 
-    [JsonConverter(typeof(StringEnumConverter))]
-    [JsonProperty("profile", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("profile")]
     public OptimizeProfile? Profile { get; set; }
 
     /// <summary>
     /// Timeout in seconds after the task will be cancelled.
     /// </summary>
-    [JsonProperty("timeout", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("timeout")]
     public int? Timeout { get; set; }
 
+    /// <summary>
+    /// Conversion and engine specific options. Depends on input_format and output_format.
+    /// </summary>
     [JsonExtensionData]
-    [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("options")]
     public Dictionary<string, object> Options { get; set; }
   }
 }

--- a/CloudConvert.API/Models/TaskOperations/ThumbnailCreateRequest.cs
+++ b/CloudConvert.API/Models/TaskOperations/ThumbnailCreateRequest.cs
@@ -1,73 +1,70 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using CloudConvert.API.Models.Enums;
 
 namespace CloudConvert.API.Models.TaskOperations
 {
   public class ThumbnailCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "thumbnail";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "thumbnail";
 
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
     /// <summary>
     /// If not set, the extension of the input file is used as input format
     /// </summary>
-    [JsonProperty("input_format", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("input_format")]
     public string Input_Format { get; set; }
 
-    [JsonProperty("output_format")]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonPropertyName("output_format")]
     public ThumbnailOutputFormat Output_Format { get; set; }
 
-    [JsonProperty("engine", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine")]
     public string Engine { get; set; }
 
-    [JsonProperty("engine_version", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine_version")]
     public string Engine_Version { get; set; }
 
     /// <summary>
     /// Choose a filename (including extension) for the output file.
     /// </summary>
-    [JsonProperty("filename", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
 
     /// <summary>
     /// Timeout in seconds after the task will be cancelled.
     /// </summary>
-    [JsonProperty("timeout", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("timeout")]
     public int? Timeout { get; set; }
 
     /// <summary>
     /// Sets the mode of sizing the thumbnail. "Max" resizes the thumbnail to fit within the width and height, but will not increase the size of the image if it is smaller than width or height. "Crop" resizes the thumbnail to fill the width and height dimensions and crops any excess image data. "Scale" enforces the thumbnail width and height by scaling. Defaults to max. 
     /// </summary>
-    [JsonProperty("fit", NullValueHandling = NullValueHandling.Ignore)]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonPropertyName("fit")]
     public ThumbnailFit? Fit { get; set; }
 
     /// <summary>
     /// Set thumbnail width in pixels.
     /// </summary>
-    [JsonProperty("width", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("width")]
     public int? Width { get; set; }
 
     /// <summary>
     /// Set thumbnail height in pixels.
     /// </summary>
-    [JsonProperty("height", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("height")]
     public int? Height { get; set; }
 
     /// <summary>
     /// Number of thumbnails to create. Defaults to 1.
     /// </summary>
-    [JsonProperty("count", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("count")]
     public int? Count { get; set; }
 
     /// <summary>
@@ -75,8 +72,7 @@ namespace CloudConvert.API.Models.TaskOperations
     /// Select input and output format above to show additional conversion options.
     /// </summary>
     [JsonExtensionData]
-    [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("options")]
     public Dictionary<string, object> Options { get; set; }
-
   }
 }

--- a/CloudConvert.API/Models/TaskOperations/WatermarkCreateRequest.cs
+++ b/CloudConvert.API/Models/TaskOperations/WatermarkCreateRequest.cs
@@ -1,43 +1,42 @@
-using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace CloudConvert.API.Models.TaskOperations
 {
   public class WatermarkCreateRequest
   {
-    [JsonProperty("operation")]
-    public static string Operation = "watermark";
+    [JsonPropertyName("operation")]
+    public string Operation { get; } = "watermark";
 
     /// <summary>
     /// The input task name(s) for this task.
     /// input: string | string[];
     /// </summary>
-    [JsonProperty("input")]
-    public dynamic Input { get; set; }
+    [JsonPropertyName("input")]
+    public object Input { get; set; }
 
     /// <summary>
     /// If not set, the extension of the input file is used as input format
     /// </summary>
-    [JsonProperty("input_format", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("input_format")]
     public string Input_Format { get; set; }
 
-
-    [JsonProperty("engine", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine")]
     public string Engine { get; set; }
 
-    [JsonProperty("engine_version", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("engine_version")]
     public string Engine_Version { get; set; }
 
     /// <summary>
     /// Choose a filename (including extension) for the output file.
     /// </summary>
-    [JsonProperty("filename", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("filename")]
     public string Filename { get; set; }
 
     /// <summary>
     /// Timeout in seconds after the task will be cancelled.
     /// </summary>
-    [JsonProperty("timeout", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("timeout")]
     public int? Timeout { get; set; }
 
     /// <summary>
@@ -45,8 +44,7 @@ namespace CloudConvert.API.Models.TaskOperations
     /// Select input and output format above to show additional conversion options.
     /// </summary>
     [JsonExtensionData]
-    [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonPropertyName("options")]
     public Dictionary<string, object> Options { get; set; }
-
   }
 }

--- a/CloudConvert.API/RestHelper.cs
+++ b/CloudConvert.API/RestHelper.cs
@@ -1,5 +1,5 @@
-using Newtonsoft.Json;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace CloudConvert.API
@@ -22,16 +22,14 @@ namespace CloudConvert.API
     public async Task<T> RequestAsync<T>(HttpRequestMessage request)
     {
       var response = await _httpClient.SendAsync(request);
-
       var responseRaw = await response.Content.ReadAsStringAsync();
 
-      return JsonConvert.DeserializeObject<T>(responseRaw);
+      return JsonSerializer.Deserialize<T>(responseRaw, DefaultJsonSerializerOptions.SerializerOptions);
     }
 
     public async Task<string> RequestAsync(HttpRequestMessage request)
     {
       var response = await _httpClient.SendAsync(request);
-
       return await response.Content.ReadAsStringAsync();
     }
   }

--- a/CloudConvert.Test/IntegrationTests.cs
+++ b/CloudConvert.Test/IntegrationTests.cs
@@ -91,7 +91,7 @@ namespace CloudConvert.Test
 
       var reqImport = new ImportUploadCreateRequest();
 
-      var importTask = await _cloudConvertAPI.CreateTaskAsync(ImportUploadCreateRequest.Operation, reqImport);
+      var importTask = await _cloudConvertAPI.CreateTaskAsync(reqImport.Operation, reqImport);
 
       var path = AppDomain.CurrentDomain.BaseDirectory + @"TestFiles/input.pdf";
       string fileName = "input.pdf";
@@ -124,7 +124,7 @@ namespace CloudConvert.Test
         Input = importTask.Data.Id
       };
 
-      var exportTask = await _cloudConvertAPI.CreateTaskAsync(ExportUrlCreateRequest.Operation, reqExport);
+      var exportTask = await _cloudConvertAPI.CreateTaskAsync(reqExport.Operation, reqExport);
 
       Assert.IsNotNull(exportTask);
 

--- a/CloudConvert.Test/IntegrationTests.cs
+++ b/CloudConvert.Test/IntegrationTests.cs
@@ -10,6 +10,8 @@ using System;
 using System.Net.Http;
 using CloudConvert.API.Models.TaskOperations;
 using System.Collections.Generic;
+using System.Dynamic;
+using System.Text.Json;
 
 namespace CloudConvert.Test
 {
@@ -85,7 +87,7 @@ namespace CloudConvert.Test
       await File.WriteAllBytesAsync(fileExport.Filename, fileBytes);
     }
 
-    
+
     [Test]
     public async Task CreateJobWithOptions()
     {
@@ -96,15 +98,15 @@ namespace CloudConvert.Test
           import_it = new ImportUploadCreateRequest(),
           convert_it = new ConvertCreateRequest
           {
-            Input = "import_it", 
+            Input = "import_it",
             Input_Format = "pdf",
             Output_Format = "jpg",
             Options = new Dictionary<string, object> {
-                  { "width", 800 },
-                  { "height", 600 },
-                  { "fit", "max" }
-                }
+              { "width", 800 },
+              { "height", 600 },
+              { "fit", "max" }
             }
+          }
         },
         Tag = "integration-test-convert-with-options"
       });
@@ -120,11 +122,11 @@ namespace CloudConvert.Test
       // get created convert task
 
       var convertTask = await _cloudConvertAPI.GetTaskAsync(job.Data.Tasks.FirstOrDefault(t => t.Name == "convert_it").Id, "payload");
-      var payload = ((Newtonsoft.Json.Linq.JObject)convertTask.Data.Payload).ToObject<Dictionary<string, object>>();
+      dynamic payload = JsonSerializer.Deserialize<ExpandoObject>(convertTask.Data.Payload.ToString());
       Assert.IsNotNull(payload);
-      Assert.AreEqual(800, payload["width"]);
-      Assert.AreEqual(600, payload["height"]);
-      Assert.AreEqual("max", payload["fit"]);
+      Assert.AreEqual(800, ((JsonElement)payload.width).GetInt32());
+      Assert.AreEqual(600, ((JsonElement)payload.height).GetInt32());
+      Assert.AreEqual("max", ((JsonElement)payload.fit).GetString());
 
     }
 

--- a/CloudConvert.Test/TestJobs.cs
+++ b/CloudConvert.Test/TestJobs.cs
@@ -1,11 +1,12 @@
 using System;
 using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using CloudConvert.API;
 using CloudConvert.API.Models;
 using CloudConvert.API.Models.JobModels;
 using Moq;
-using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace CloudConvert.Test
@@ -24,7 +25,7 @@ namespace CloudConvert.Test
         var path = @"Responses/jobs.json";
         string json = File.ReadAllText(path);
         _cloudConvertAPI.Setup(cc => cc.GetAllJobsAsync(filter))
-                        .ReturnsAsync(JsonConvert.DeserializeObject<ListResponse<JobResponse>>(json));
+                        .ReturnsAsync(JsonSerializer.Deserialize<ListResponse<JobResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
         var jobs = await _cloudConvertAPI.Object.GetAllJobsAsync(filter);
 
@@ -35,7 +36,7 @@ namespace CloudConvert.Test
       {
         if (ex.InnerException != null)
         {
-          var error = JsonConvert.DeserializeObject<ErrorResponse>(ex.InnerException.Message);
+          var error = JsonSerializer.Deserialize<ErrorResponse>(ex.InnerException.Message, DefaultJsonSerializerOptions.SerializerOptions);
         }
         else
         {
@@ -56,7 +57,7 @@ namespace CloudConvert.Test
       var path = AppDomain.CurrentDomain.BaseDirectory + @"Responses/job_created.json";
       string json = File.ReadAllText(path);
       _cloudConvertAPI.Setup(cc => cc.CreateJobAsync(req))
-                      .ReturnsAsync(JsonConvert.DeserializeObject<Response<JobResponse>>(json));
+                      .ReturnsAsync(JsonSerializer.Deserialize<Response<JobResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
       var job = await _cloudConvertAPI.Object.CreateJobAsync(req);
 
@@ -73,7 +74,7 @@ namespace CloudConvert.Test
       var path = AppDomain.CurrentDomain.BaseDirectory + @"Responses/job.json";
       string json = File.ReadAllText(path);
       _cloudConvertAPI.Setup(cc => cc.GetJobAsync(id))
-                      .ReturnsAsync(JsonConvert.DeserializeObject<Response<JobResponse>>(json));
+                      .ReturnsAsync(JsonSerializer.Deserialize<Response<JobResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
       var job = await _cloudConvertAPI.Object.GetJobAsync(id);
 
@@ -90,7 +91,7 @@ namespace CloudConvert.Test
       var path = AppDomain.CurrentDomain.BaseDirectory + @"Responses/job_finished.json";
       string json = File.ReadAllText(path);
       _cloudConvertAPI.Setup(cc => cc.WaitJobAsync(id))
-                      .ReturnsAsync(JsonConvert.DeserializeObject<Response<JobResponse>>(json));
+                      .ReturnsAsync(JsonSerializer.Deserialize<Response<JobResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
       var job = await _cloudConvertAPI.Object.WaitJobAsync(id);
 
@@ -108,6 +109,5 @@ namespace CloudConvert.Test
 
       await _cloudConvertAPI.Object.DeleteJobAsync(id);
     }
-
   }
 }

--- a/CloudConvert.Test/TestSignedUrl.cs
+++ b/CloudConvert.Test/TestSignedUrl.cs
@@ -41,16 +41,13 @@ namespace CloudConvert.Test
     
       };
 
-
       string signedUrl = _cloudConvertAPI.CreateSignedUrl(baseUrl, signingSecret, job, cacheKey);
 
 
       StringAssert.StartsWith(baseUrl, signedUrl);
       StringAssert.Contains("?job=", signedUrl);
       StringAssert.Contains("&cache_key=mykey", signedUrl);
-      StringAssert.Contains("&s=05521324eb16876aac906f2edc42a7ebfe6e71743e6cb965c4b3bf224c2b581f", signedUrl);
-
-
+      StringAssert.Contains("&s=81213540c2ccdf3330a0cf237642f14b381f57cf5bbffe293eb118468fde700b", signedUrl);
     }
   }
 }

--- a/CloudConvert.Test/TestTasks.cs
+++ b/CloudConvert.Test/TestTasks.cs
@@ -10,7 +10,7 @@ using CloudConvert.API.Models.TaskOperations;
 using CloudConvert.Test.Extensions;
 using Moq;
 using Moq.Protected;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NUnit.Framework;
 
 namespace CloudConvert.Test
@@ -29,7 +29,7 @@ namespace CloudConvert.Test
 
         var cloudConvertApi = new Mock<ICloudConvertAPI>();
         cloudConvertApi.Setup(cc => cc.GetAllTasksAsync(filter))
-                        .ReturnsAsync(JsonConvert.DeserializeObject<ListResponse<TaskResponse>>(json));
+                       .ReturnsAsync(JsonSerializer.Deserialize<ListResponse<TaskResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
         var tasks = await cloudConvertApi.Object.GetAllTasksAsync(filter);
 
@@ -40,7 +40,7 @@ namespace CloudConvert.Test
       {
         if (ex.InnerException != null)
         {
-          var error = JsonConvert.DeserializeObject<ErrorResponse>(ex.InnerException.Message);
+          var error = JsonSerializer.Deserialize<ErrorResponse>(ex.InnerException.Message, DefaultJsonSerializerOptions.SerializerOptions);
         }
         else
         {
@@ -68,10 +68,10 @@ namespace CloudConvert.Test
       string json = File.ReadAllText(path);
 
       var cloudConvertApi = new Mock<ICloudConvertAPI>();
-      cloudConvertApi.Setup(cc => cc.CreateTaskAsync(ConvertCreateRequest.Operation, req))
-                      .ReturnsAsync(JsonConvert.DeserializeObject<Response<TaskResponse>>(json));
+      cloudConvertApi.Setup(cc => cc.CreateTaskAsync(req.Operation, req))
+                     .ReturnsAsync(JsonSerializer.Deserialize<Response<TaskResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
-      var task = await cloudConvertApi.Object.CreateTaskAsync(ConvertCreateRequest.Operation, req);
+      var task = await cloudConvertApi.Object.CreateTaskAsync(req.Operation, req);
 
       Assert.IsNotNull(task);
       Assert.IsTrue(task.Data.Status == API.Models.Enums.TaskStatus.waiting);
@@ -87,7 +87,7 @@ namespace CloudConvert.Test
 
       var _cloudConvertAPI = new Mock<ICloudConvertAPI>();
       _cloudConvertAPI.Setup(cc => cc.GetTaskAsync(id, null))
-                      .ReturnsAsync(JsonConvert.DeserializeObject<Response<TaskResponse>>(json));
+                      .ReturnsAsync(JsonSerializer.Deserialize<Response<TaskResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
       var task = await _cloudConvertAPI.Object.GetTaskAsync("9de1a620-952c-4482-9d44-681ae28d72a1");
 
@@ -105,7 +105,7 @@ namespace CloudConvert.Test
 
       var cloudConvertApi = new Mock<ICloudConvertAPI>();
       cloudConvertApi.Setup(cc => cc.WaitTaskAsync(id))
-                      .ReturnsAsync(JsonConvert.DeserializeObject<Response<TaskResponse>>(json));
+                      .ReturnsAsync(JsonSerializer.Deserialize<Response<TaskResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
       var task = await cloudConvertApi.Object.WaitTaskAsync(id);
 
@@ -133,10 +133,10 @@ namespace CloudConvert.Test
 
       var path = AppDomain.CurrentDomain.BaseDirectory + @"Responses/upload_task_created.json";
       string json = File.ReadAllText(path);
-      cloudConvertApi.Setup(cc => cc.CreateTaskAsync(ImportUploadCreateRequest.Operation, req))
-                      .ReturnsAsync(JsonConvert.DeserializeObject<Response<TaskResponse>>(json));
+      cloudConvertApi.Setup(cc => cc.CreateTaskAsync(req.Operation, req))
+                      .ReturnsAsync(JsonSerializer.Deserialize<Response<TaskResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
-      var task = await cloudConvertApi.Object.CreateTaskAsync(ImportUploadCreateRequest.Operation, req);
+      var task = await cloudConvertApi.Object.CreateTaskAsync(req.Operation, req);
 
       Assert.IsNotNull(task);
 
@@ -161,7 +161,7 @@ namespace CloudConvert.Test
       var req = new ImportUploadCreateRequest();
       var cloudConvertApi = new CloudConvertAPI(restHelper, "API_KEY");
 
-      var task = await cloudConvertApi.CreateTaskAsync(ImportUploadCreateRequest.Operation, req);
+      var task = await cloudConvertApi.CreateTaskAsync(req.Operation, req);
 
       Assert.IsNotNull(task);
       httpMessageHandlerMock.VerifyRequest("/import/upload", Times.Once());


### PR DESCRIPTION
Hi,

I have changed the JSON implementation from `Newtonsoft.Json` to `System.Text.Json`.

We know this is a big one.

Why do we want to change the JSON serializer?

* `Newtonsoft.Json` is no longer state-of-the-art.
* `.NET 5` and ongoing have its own Json serializer implementation.
* One package less to depend on.
* Cleaner code (no need for `NullValueHandling = NullValueHandling.Ignore`, etc.). Said option is now set in ‎`DefaultJsonSerializerOptions.cs`.

All testes are passing. The hash sum of one test (URL) had to be changed because an unneeded field that was there beforehand is no longer present in the resulting JSON.

A few fields had to be changed from `dynamic` to `object`. But the resulting JSON is the same. `System.Text.Json` does not support `dynamic`.

What I am not 100% sure is if it works correctly is the `[JsonExtensionData]` tag.

Could you please provide some example data for the `Options` field for `CaptureWebsiteCreateRequest`, so I can compare the resulting Jsons of `Newtonsoft` and `System.Text.Json`? Thank you.

Implements https://github.com/cloudconvert/cloudconvert-dotnet/issues/8.