### PR TITLE
Add CancellationToken support

### DIFF
--- a/CloudConvert.API/RestHelper.cs
+++ b/CloudConvert.API/RestHelper.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CloudConvert.API
@@ -19,18 +20,18 @@ namespace CloudConvert.API
       _httpClient = httpClient;
     }
 
-    public async Task<T> RequestAsync<T>(HttpRequestMessage request)
+    public async Task<T> RequestAsync<T>(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-      var response = await _httpClient.SendAsync(request);
-      var responseRaw = await response.Content.ReadAsStringAsync();
+      var response = await _httpClient.SendAsync(request, cancellationToken);
+      var responseRaw = await response.Content.ReadAsStringAsync(cancellationToken);
 
       return JsonSerializer.Deserialize<T>(responseRaw, DefaultJsonSerializerOptions.SerializerOptions);
     }
 
-    public async Task<string> RequestAsync(HttpRequestMessage request)
+    public async Task<string> RequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-      var response = await _httpClient.SendAsync(request);
-      return await response.Content.ReadAsStringAsync();
+      var response = await _httpClient.SendAsync(request, cancellationToken);
+      return await response.Content.ReadAsStringAsync(cancellationToken);
     }
   }
 }

--- a/CloudConvert.API/WebApiHandler.cs
+++ b/CloudConvert.API/WebApiHandler.cs
@@ -25,19 +25,19 @@ namespace CloudConvert.API
       {
         if (writeLog)
         {
-          var requestString = request.Content != null ? await request.Content.ReadAsStringAsync() : string.Empty;
+          var requestString = request.Content != null ? await request.Content.ReadAsStringAsync(cancellationToken) : string.Empty;
         }
 
         var response = await base.SendAsync(request, cancellationToken);
 
         if (writeLog)
         {
-          string responseString = (await response.Content.ReadAsStringAsync()).TrimLengthWithEllipsis(20000);
+          string responseString = (await response.Content.ReadAsStringAsync(cancellationToken)).TrimLengthWithEllipsis(20000);
         }
 
         if ((int)response.StatusCode >= 400)
         {
-          throw new WebApiException((await response.Content.ReadAsStringAsync()).TrimLengthWithEllipsis(20000));
+          throw new WebApiException((await response.Content.ReadAsStringAsync(cancellationToken)).TrimLengthWithEllipsis(20000));
         }
 
         return response;

--- a/CloudConvert.Test/TestJobs.cs
+++ b/CloudConvert.Test/TestJobs.cs
@@ -23,7 +23,7 @@ namespace CloudConvert.Test
 
         var path = @"Responses/jobs.json";
         string json = File.ReadAllText(path);
-        _cloudConvertAPI.Setup(cc => cc.GetAllJobsAsync(filter))
+        _cloudConvertAPI.Setup(cc => cc.GetAllJobsAsync(filter, default))
                         .ReturnsAsync(JsonSerializer.Deserialize<ListResponse<JobResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
         var jobs = await _cloudConvertAPI.Object.GetAllJobsAsync(filter);
@@ -55,7 +55,7 @@ namespace CloudConvert.Test
 
       var path = AppDomain.CurrentDomain.BaseDirectory + @"Responses/job_created.json";
       string json = File.ReadAllText(path);
-      _cloudConvertAPI.Setup(cc => cc.CreateJobAsync(req))
+      _cloudConvertAPI.Setup(cc => cc.CreateJobAsync(req, default))
                       .ReturnsAsync(JsonSerializer.Deserialize<Response<JobResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
       var job = await _cloudConvertAPI.Object.CreateJobAsync(req);
@@ -72,7 +72,7 @@ namespace CloudConvert.Test
 
       var path = AppDomain.CurrentDomain.BaseDirectory + @"Responses/job.json";
       string json = File.ReadAllText(path);
-      _cloudConvertAPI.Setup(cc => cc.GetJobAsync(id))
+      _cloudConvertAPI.Setup(cc => cc.GetJobAsync(id, default))
                       .ReturnsAsync(JsonSerializer.Deserialize<Response<JobResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
       var job = await _cloudConvertAPI.Object.GetJobAsync(id);
@@ -89,7 +89,7 @@ namespace CloudConvert.Test
 
       var path = AppDomain.CurrentDomain.BaseDirectory + @"Responses/job_finished.json";
       string json = File.ReadAllText(path);
-      _cloudConvertAPI.Setup(cc => cc.WaitJobAsync(id))
+      _cloudConvertAPI.Setup(cc => cc.WaitJobAsync(id, default))
                       .ReturnsAsync(JsonSerializer.Deserialize<Response<JobResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
       var job = await _cloudConvertAPI.Object.WaitJobAsync(id);
@@ -104,7 +104,7 @@ namespace CloudConvert.Test
     {
       string id = "cd82535b-0614-4b23-bbba-b24ab0e892f7";
 
-      _cloudConvertAPI.Setup(cc => cc.DeleteJobAsync(id));
+      _cloudConvertAPI.Setup(cc => cc.DeleteJobAsync(id, default));
 
       await _cloudConvertAPI.Object.DeleteJobAsync(id);
     }

--- a/CloudConvert.Test/TestJobs.cs
+++ b/CloudConvert.Test/TestJobs.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using CloudConvert.API;
 using CloudConvert.API.Models;

--- a/CloudConvert.Test/TestSignedUrl.cs
+++ b/CloudConvert.Test/TestSignedUrl.cs
@@ -1,4 +1,3 @@
-
 using CloudConvert.API;
 using CloudConvert.API.Models.JobModels;
 using CloudConvert.API.Models.TaskOperations;

--- a/CloudConvert.Test/TestTasks.cs
+++ b/CloudConvert.Test/TestTasks.cs
@@ -28,7 +28,7 @@ namespace CloudConvert.Test
         string json = File.ReadAllText(path);
 
         var cloudConvertApi = new Mock<ICloudConvertAPI>();
-        cloudConvertApi.Setup(cc => cc.GetAllTasksAsync(filter))
+        cloudConvertApi.Setup(cc => cc.GetAllTasksAsync(filter, default))
                        .ReturnsAsync(JsonSerializer.Deserialize<ListResponse<TaskResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
         var tasks = await cloudConvertApi.Object.GetAllTasksAsync(filter);
@@ -68,7 +68,7 @@ namespace CloudConvert.Test
       string json = File.ReadAllText(path);
 
       var cloudConvertApi = new Mock<ICloudConvertAPI>();
-      cloudConvertApi.Setup(cc => cc.CreateTaskAsync(req.Operation, req))
+      cloudConvertApi.Setup(cc => cc.CreateTaskAsync(req.Operation, req, default))
                      .ReturnsAsync(JsonSerializer.Deserialize<Response<TaskResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
       var task = await cloudConvertApi.Object.CreateTaskAsync(req.Operation, req);
@@ -86,7 +86,7 @@ namespace CloudConvert.Test
       string json = File.ReadAllText(path);
 
       var _cloudConvertAPI = new Mock<ICloudConvertAPI>();
-      _cloudConvertAPI.Setup(cc => cc.GetTaskAsync(id, null))
+      _cloudConvertAPI.Setup(cc => cc.GetTaskAsync(id, null, default))
                       .ReturnsAsync(JsonSerializer.Deserialize<Response<TaskResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
       var task = await _cloudConvertAPI.Object.GetTaskAsync("9de1a620-952c-4482-9d44-681ae28d72a1");
@@ -104,7 +104,7 @@ namespace CloudConvert.Test
       string json = File.ReadAllText(path);
 
       var cloudConvertApi = new Mock<ICloudConvertAPI>();
-      cloudConvertApi.Setup(cc => cc.WaitTaskAsync(id))
+      cloudConvertApi.Setup(cc => cc.WaitTaskAsync(id, default))
                       .ReturnsAsync(JsonSerializer.Deserialize<Response<TaskResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
       var task = await cloudConvertApi.Object.WaitTaskAsync(id);
@@ -120,7 +120,7 @@ namespace CloudConvert.Test
       string id = "9de1a620-952c-4482-9d44-681ae28d72a1";
 
       var cloudConvertApi = new Mock<ICloudConvertAPI>();
-      cloudConvertApi.Setup(cc => cc.DeleteTaskAsync(id));
+      cloudConvertApi.Setup(cc => cc.DeleteTaskAsync(id, default));
 
       await cloudConvertApi.Object.DeleteTaskAsync("c8a8da46-3758-45bf-b983-2510e3170acb");
     }
@@ -133,7 +133,7 @@ namespace CloudConvert.Test
 
       var path = AppDomain.CurrentDomain.BaseDirectory + @"Responses/upload_task_created.json";
       string json = File.ReadAllText(path);
-      cloudConvertApi.Setup(cc => cc.CreateTaskAsync(req.Operation, req))
+      cloudConvertApi.Setup(cc => cc.CreateTaskAsync(req.Operation, req, default))
                       .ReturnsAsync(JsonSerializer.Deserialize<Response<TaskResponse>>(json, DefaultJsonSerializerOptions.SerializerOptions));
 
       var task = await cloudConvertApi.Object.CreateTaskAsync(req.Operation, req);
@@ -144,7 +144,7 @@ namespace CloudConvert.Test
       byte[] file = File.ReadAllBytes(pathFile);
       string fileName = "input.pdf";
 
-      cloudConvertApi.Setup(cc => cc.UploadAsync(task.Data.Result.Form.Url.ToString(), file, fileName, task.Data.Result.Form.Parameters));
+      cloudConvertApi.Setup(cc => cc.UploadAsync(task.Data.Result.Form.Url.ToString(), file, fileName, task.Data.Result.Form.Parameters, default));
 
       await cloudConvertApi.Object.UploadAsync(task.Data.Result.Form.Url.ToString(), file, fileName, task.Data.Result.Form.Parameters);
     }


### PR DESCRIPTION
Added `CancellationToken` parameters to `async` methods to allow cancellation of long-running or hanging tasks.

Included a basic test case to verify cancellation behavior. Not fully sure if a test is needed or appropriate in this form.