### PR TITLE
fix: add ConfigureAwait(false) throughout async code to prevent synchronization context deadlocks

### DIFF
--- a/CloudConvert.API/RestHelper.cs
+++ b/CloudConvert.API/RestHelper.cs
@@ -22,12 +22,17 @@ namespace CloudConvert.API
 
     internal async Task<T> RequestAsync<T>(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-      var response = await _httpClient.SendAsync(request, cancellationToken);
-      var responseRaw = await response.Content.ReadAsStringAsync(cancellationToken);
+      var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-      // Handle empty response body (e.g., HTTP 204 No Content)
-      // System.Text.Json throws when trying to deserialize an empty string
-      if (string.IsNullOrWhiteSpace(responseRaw) || response.StatusCode == System.Net.HttpStatusCode.NoContent)
+      // Short-circuit earlier as 204 will never have a body to read
+      if (response.StatusCode == System.Net.HttpStatusCode.NoContent)
+      {
+        return default;
+      }
+
+      var responseRaw = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+      if (string.IsNullOrWhiteSpace(responseRaw))
       {
         return default;
       }
@@ -37,8 +42,8 @@ namespace CloudConvert.API
 
     internal async Task<string> RequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-      var response = await _httpClient.SendAsync(request, cancellationToken);
-      return await response.Content.ReadAsStringAsync(cancellationToken);
+      var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+      return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
     }
   }
 }

--- a/CloudConvert.API/WebApiHandler.cs
+++ b/CloudConvert.API/WebApiHandler.cs
@@ -12,11 +12,12 @@ namespace CloudConvert.API
     {
       try
       {
-        var response = await base.SendAsync(request, cancellationToken);
+        var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
         if ((int)response.StatusCode >= 400)
         {
-          throw new WebApiException((await response.Content.ReadAsStringAsync(cancellationToken)).TrimLengthWithEllipsis(20000));
+          var errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+          throw new WebApiException(errorBody.TrimLengthWithEllipsis(20000));
         }
 
         return response;


### PR DESCRIPTION
## Problem
Users calling any `async` method on `CloudConvertAPI` (`CreateJobAsync()`, `UploadAsync()`, `WaitJobAsync()`, etc.) in environments with a synchronization context (ASP.NET classic, WinForms, WPF) would experience a deadlock if the call chain blocked anywhere with `.Result` or `.Wait()`.

## Fix
- Added `ConfigureAwait(false)` to every `await` call in `WebApiHandler` and `RestHelper`, so continuations resume on any available thread pool thread rather than the captured synchronization context.
- Additionally, I refactored `RestHelper.RequestAsync<T>()` to short-circuit on `HTTP 204 NoContent` before attempting to read the response body, avoiding an unnecessary `ReadAsStringAsync()` call.

Fixes: https://github.com/cloudconvert/cloudconvert-dotnet/issues/14

## References
- [ConfigureAwait FAQ - .NET Blog](https://devblogs.microsoft.com/dotnet/configureawait-faq/)